### PR TITLE
Fix for select field overlay

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -851,6 +851,8 @@
 
 /****************************************************/
 /* modals: ACF customization */
+.select2-container {
+  z-index: 999992; }
 #layotter-edit > .acf-error-message:first-child {
   position: absolute;
   top: 18px;


### PR DESCRIPTION
The select2 overlay was positioned behind the Layotter overlay. I changed the z-index value to maximum in order to fix the problem.