### PR TITLE
Fix for select field overlay

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -1160,6 +1160,12 @@ $darkgray: #CCCCCC;
 /****************************************************/
 /* modals: ACF customization */
 
+// ACF 5.6+
+
+.select2-container {
+    z-index: 999992;
+}
+
 // ACF 5
 #layotter-edit {
     > .acf-error-message:first-child { // form validation error


### PR DESCRIPTION
The select2 overlay was positioned behind the Layotter overlay. I changed the z-index value to maximum in order to fix the problem.